### PR TITLE
Rename language pack to language extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# English Language Pack for Flarum
+# English Language Extension for Flarum
 
 ## Installation
 
-This language pack is bundled with [Flarum](http://flarum.org/download/).
+This language extension is bundled with [Flarum](http://flarum.org/download/).
 
 ## Translating Flarum
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -15,17 +15,17 @@ return function (Dispatcher $events) {
         }
 
         if ($name === null) {
-            throw new RuntimeException("Language pack ".__DIR__." needs a \"name\" in flarum.json.");
+            throw new RuntimeException("Language extension ".__DIR__." needs a \"name\" in flarum.json.");
         }
 
         if ($locale === null) {
-            throw new RuntimeException("Language pack {$name} needs a \"locale\" in flarum.json.");
+            throw new RuntimeException("Language extension {$name} needs a \"locale\" in flarum.json.");
         }
 
         $event->addLocale($locale, $name);
 
         if (! is_dir($localeDir = __DIR__.'/locale')) {
-            throw new RuntimeException("Language pack {$name} needs a \"locale\" subdirectory.");
+            throw new RuntimeException("Language extension {$name} needs a \"locale\" subdirectory.");
         }
 
         if (file_exists($file = $localeDir.'/config.js')) {

--- a/flarum.json
+++ b/flarum.json
@@ -2,7 +2,7 @@
     "name": "english",
     "title": "English",
     "locale": "en",
-    "description": "English language pack.",
+    "description": "English language extension.",
     "keywords": ["language"],
     "version": "0.1.0-beta.3",
     "author": {


### PR DESCRIPTION
Because it's actually a full extension, even if the skeleton is slightly
different. It may be confusing to use a different naming because it will
be later released in the Extension Store.