### PR TITLE
Change the Font Awesome icon

### DIFF
--- a/flarum.json
+++ b/flarum.json
@@ -19,7 +19,7 @@
         "issues": "https://github.com/flarum/core/issues"
     },
     "icon": {
-        "name": "globe",
+        "name": "language",
         "backgroundColor": "#eee",
         "color": "#000"
     }


### PR DESCRIPTION
The "language" icon is better and more specific by default than the
"globe" icon, which can be used on many non-language extensions.