### PR TITLE
Standardization

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# http://editorconfig.org/
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{json,php}]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+# Automatically normalize line endings for all text-based files
+# http://git-scm.com/docs/gitattributes#_end_of_line_conversion
+* text=auto
+
+# For the following file types, normalize line endings to LF on
+# check in and prevent conversion to CRLF when they are checked out
+# (this is required in order to prevent newline related issues like,
+# for example, after the build script is run)
+.*     text eol=lf
+*.js   text eol=lf
+*.json text eol=lf
+*.md   text eol=lf
+*.php  text eol=lf
+*.yml  text eol=lf
+
+# Exclude the following files when exporting an archive
+# https://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes#Exporting-Your-Repository
+.editorconfig  export-ignore
+.gitattributes export-ignore
+.gitignore     export-ignore
+README.md      export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+# Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+*.cab
+*.msi
+*.msm
+*.msp
+*.lnk
+
+# Mac OS
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+._*
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# Linux
+*~
+.directory
+.Trash-*
+
+# Backup and log files
+*.bak
+*.log
+
+# Git
+.git


### PR DESCRIPTION
Add .editorconfig for consistent coding styles, normalize line endings and export-ignore (ensure to normalize line endings to Unix (LF) and exclude some extra files which are uncessary to the extension itself when exporting an archive) and ignore junks files to be added (it includes common OS junk files, some common backup and log files and ensure that .git is ignored).