### PR TITLE
Valid SVG 1.1 Markup

### DIFF
--- a/icon.svg
+++ b/icon.svg
@@ -1,6 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 30" width="1200" height="600">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 60 30" width="1200" height="600">
 <clipPath id="t">
-	<path d="M30,15 h30 v15 z v15 h-30 z h-30 v-15 z v-15 h30 z"/>
+  <path d="M30,15 h30 v15 z v15 h-30 z h-30 v-15 z v-15 h30 z"/>
 </clipPath>
 <path d="M0,0 v30 h60 v-30 z" fill="#00247d"/>
 <path d="M0,0 L60,30 M60,0 L0,30" stroke="#fff" stroke-width="6"/>


### PR DESCRIPTION
The original markup was checked as XML. New changes make it valid as valid SVG 1.1.
I also replaced the original tab indent to a two spaces indent for Flarum's coding standards.