### PR TITLE
Update translating instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,4 @@ This language pack is bundled with [Flarum](http://flarum.org/download/).
 
 ## Translating Flarum
 
-1. Fork this repository.
-2. Edit the [flarum.json](flarum.json) file:
-  - `name` A lowercase and hyphens only name (e.g. **french**, **drunk-pirates**).
-  - `title` A short descriptive label for the extension list (e.g. **French**, **Drunk Pirates Arr**).
-  - `locale` An [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) code of your locale, or a short identifier of at least 3 characters to prevent conflicts (e.g. **fr**, **pirate**).
-  - `description` Complete description, possible in the same language (e.g. **Française pour vous**, **Arrr matey hoist the sails**).
-  - `author` Replace with your own information.
-  - `icon` Change to suit your needs, play with the name for the FontAwesome icon, color for the icon color and background for the background color of the icon.
-3. Modify the files under `/locale` to suit your needs. These hold all the actual translations.
+Because Flarum is at an early development stage, instructions to translate it are currently unavailable. Please check [our documentation](http://flarum.org/docs/translate/) when it will be written.


### PR DESCRIPTION
Current instructions of the README.mf file are wrong because the L10n process changed a lot. I changed these instructions with more generic ones for now.