### PR TITLE
Group translation keys by sub-key instead of prefix

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -323,22 +323,25 @@ core:
     # This string is displayed in place of the username of deleted user account.
     deleted_user_text: "[deleted]"
 
+    # Thes strings are displayed as error messages.
+    error:
+      generic_message: Oops! Something went wrong. Please reload the page and try again.
+      permission_denied_message: You do not have permission to do that.
+      not_found_message: The requested resource was not found.
+
     # This string is displayed as the tooltip for the badge on a soft-deleted discussion.
     hidden_discussion_tooltip: Hidden
 
-    # This string is displayed when an error occurs.
-    oops_message: Oops! Something went wrong. Please reload the page and try again.
+    #These strings are used as suffixes when abbreviating numbers.
+    number_suffix:
+      kilo_text: K
+      mega_text: M
 
     # These strings are used to punctuate a series of items.
     series:
       glue_text: ", "
       two_text: "{first} and {second}"
       three_text: "{first}, {second}, and {third}"
-
-    #These strings are used as suffixes when abbreviating numbers.
-    suffix:
-      kilo_text: K
-      mega_text: M
 
   ##
   # REUSED STRINGS - These keys should not be used directly in code!

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -4,302 +4,347 @@ core:
   # UNIQUE KEYS - The following keys are used in only one location each.
   ##
 
-  # Strings in this namespace are used by the forum user interface.
-  forum:
-
-    # These strings are used in the Change Email modal dialog.
-    change_email_confirmation_message: => core.ref.confirmation_email_sent
-    change_email_dismiss_button: => core.ref.okay
-    change_email_submit_button: => core.ref.save_changes
-    change_email_title: => core.ref.change_email
-
-    # These strings are used in the Change Password modal dialog.
-    change_password_send_button: Send Password Reset Email
-    change_password_text: Click the button below and check your email for a link to change your password.
-    change_password_title: => core.ref.change_password
-
-    # These strings are used by the composer controls.
-    composer_close_tooltip: Close
-    composer_exit_full_screen_tooltip: Exit Full Screen
-    composer_full_screen_tooltip: Full Screen
-    composer_minimize_tooltip: Minimize
-
-    # These strings are used by the composer when starting a discussion.
-    composer_discussion_body_placeholder: Write a Post...
-    composer_discussion_discard_confirmation: You have not posted your discussion. Do you wish to discard it?
-    composer_discussion_submit_button: Post Discussion
-    composer_discussion_title_placeholder: Discussion Title
-
-    # These strings are used by the composer when editing a post.
-    composer_edit_discard_confirmation: You have not saved your changes. Do you wish to discard them?
-    composer_edit_post_link: "Post #{number} in {discussion}"
-    composer_edit_submit_button: => core.ref.save_changes
-
-    # These strings are used by the composer when replying to a discussion.
-    composer_reply_body_placeholder: => core.ref.write_a_reply
-    composer_reply_discard_confirmation: You have not posted your reply. Do you wish to discard it?
-    composer_reply_posted_message: Your reply was posted.
-    composer_reply_submit_button: Post Reply
-    composer_reply_view_button: View
-
-    # These strings are used by the discussion control buttons.
-    discussion_controls_cannot_reply_button: Can't Reply
-    discussion_controls_cannot_reply_text: You don't have permission to reply to this discussion.
-    discussion_controls_delete_button: => core.ref.delete
-    discussion_controls_delete_confirmation: Are you sure you want to delete this discussion?
-    discussion_controls_delete_forever_button: => core.ref.delete_forever
-    discussion_controls_log_in_to_reply_button: Log In to Reply
-    discussion_controls_rename_button: Rename
-    discussion_controls_rename_text: Enter a new title for this discussion:
-    discussion_controls_reply_button: Reply
-    discussion_controls_restore_button: => core.ref.restore
-
-    # These strings are used in the discussion list.
-    discussion_list_empty_text: Looks like there are no discussions here. Why don't you create a new one?
-    discussion_list_load_more_button: => core.ref.load_more
-    discussion_list_mark_as_read_tooltip: Mark as Read
-    discussion_list_replied_text: "{username} replied {ago}"
-    discussion_list_started_text: "{username} started {ago}"
-
-    # These strings are used in the Edit User modal dialog (admin function).
-    edit_user_email_label: => core.ref.email
-    edit_user_password_label: => core.ref.password
-    edit_user_submit_button: => core.ref.save_changes
-    edit_user_username_label: => core.ref.username
-
-    # These strings are used in the Forgot Password modal dialog.
-    forgot_password_dismiss_button: => core.ref.okay
-    forgot_password_email_placeholder: => core.ref.email
-    forgot_password_email_sent_message: We've sent you an email containing a link to reset your password. Check your spam folder if you don't receive it within the next minute or two.
-    forgot_password_submit_button: Recover Password
-    forgot_password_text: Enter your email address and we will send you a link to reset your password.
-    forgot_password_title: Forgot Password
-
-    # These strings are used in the header and session dropdown menu.
-    header_admin_button: Administration
-    header_log_in_link: => core.ref.log_in
-    header_log_out_button: => core.ref.log_out
-    header_profile_button: Profile
-    header_search_placeholder: Search Forum
-    header_settings_button: => core.ref.settings
-    header_sign_up_link: => core.ref.sign_up
-
-    # These strings are used on the index page, peripheral to the discussion list.
-    index_all_discussions_link: => core.ref.all_discussions
-    index_cannot_start_discussion_button: Can't Start Discussion
-    index_mark_all_as_read_tooltip: => core.ref.mark_all_as_read
-    index_refresh_tooltip: Refresh
-    index_start_discussion_button: Start a Discussion
-
-    # These strings are used by the sorting control above the discussion list.
-    index_sort_latest_button: Latest
-    index_sort_newest_button: Newest
-    index_sort_oldest_button: Oldest
-    index_sort_relevance_button: Relevance
-    index_sort_top_button: Top
-
-    # These strings are used in the Log In modal dialog.
-    log_in_confirmation_required_message: "You need to confirm your email before you can log in. We've sent a confirmation email to {email}. If it doesn't arrive soon, check your spam folder."
-    log_in_forgot_password_link: Forgot password?
-    log_in_invalid_login_message: Your login details were incorrect.
-    log_in_password_placeholder: => core.ref.password
-    log_in_sign_up_text: "Don't have an account? <a>Sign Up</a>"
-    log_in_submit_button: => core.ref.log_in
-    log_in_title: => core.ref.log_in
-    log_in_username_or_email_placeholder: Username or Email
-
-    # These strings are used by the Notifications dropdown, a.k.a. "the bell".
-    notifications_discussion_renamed_text: "{username} changed the title"
-    notifications_empty_text: No Notifications
-    notifications_mark_all_as_read_tooltip: => core.ref.mark_all_as_read
-    notifications_title: => core.ref.notifications
-    notifications_tooltip: => core.ref.notifications
-
-    # These strings are used by tooltips displayed for individual posts.
-    post_edited_tooltip: "{username} edited {ago}"
-    post_number_tooltip: "Post #{number}"
-
-    # These strings are used by the post control buttons.
-    post_controls_delete_button: => core.ref.delete
-    post_controls_delete_forever_button: => core.ref.delete_forever
-    post_controls_edit_button: => core.ref.edit
-    post_controls_restore_button: => core.ref.restore
-
-    # These strings are used in the scrubber to the right of the post stream.
-    post_scrubber_now_link: Now
-    post_scrubber_original_post_link: Original Post
-    post_scrubber_unread_text: "{count} unread"
-    post_scrubber_viewing_text: "{index} of {count} post|{index} of {count} posts"
-
-    # These strings are displayed between posts in the post stream.
-    post_stream_discussion_renamed_text: "{username} changed the title from {old} to {new}."
-    post_stream_reply_placeholder: => core.ref.write_a_reply
-    post_stream_time_lapsed_text: "{period} later"
-
-    # These strings are used by the search results dropdown list.
-    search_all_discussions_button: 'Search all discussions for "{query}"'
-    search_discussions_heading: => core.ref.discussions
-    search_users_heading: Users
-
-    # These strings are used in the Settings page.
-    settings_account_heading: Account
-    settings_change_email_button: => core.ref.change_email
-    settings_change_password_button: => core.ref.change_password
-    settings_notifications_heading: => core.ref.notifications
-    settings_privacy_disclose_online_label: Allow others to see when I am online
-    settings_privacy_heading: Privacy
-    settings_title: => core.ref.settings
-
-    # These strings are used in the Notifications grid on the Settings page.
-    settings_notify_by_email_heading: => core.ref.email
-    settings_notify_by_web_heading: Web
-    settings_notify_discussion_renamed_label: Someone renames a discussion I started
-
-    # These strings are used in the Sign Up modal dialog.
-    sign_up_confirmation_message: => core.ref.confirmation_email_sent
-    sign_up_email_placeholder: => core.ref.email
-    sign_up_dismiss_button: => core.ref.okay
-    sign_up_log_in_text: "Already have an account? <a>Log In</a>"
-    sign_up_password_placeholder: => core.ref.password
-    sign_up_submit_button: => core.ref.sign_up
-    sign_up_title: => core.ref.sign_up
-    sign_up_username_placeholder: => core.ref.username
-    sign_up_welcome_text: "Welcome, {username}!"
-
-    # These strings are used in the user profile page and profile popup.
-    user_bio_placeholder: Write something about yourself
-    user_deleted_text: "[deleted]"
-    user_discussions_link: => core.ref.discussions
-    user_joined_date_text: "Joined {ago}"
-    user_online_text: Online
-    user_posts_load_more_button: => core.ref.load_more
-    user_posts_link: Posts
-    user_settings_link: => core.ref.settings
-
-    # These strings are used to control the avatar in the user profile page.
-    user_avatar_remove_button: Remove
-    user_avatar_upload_button: Upload
-
-    # These strings are found on the user profile page (admin function).
-    user_controls_button: Controls
-    user_controls_delete_button: => core.ref.delete
-    user_controls_delete_confirmation: Are you sure you want to delete this user? All of the user's posts will be deleted.
-    user_controls_edit_button: => core.ref.edit
-
   # Strings in this namespace are used by the admin interface.
   admin:
 
     # These strings are used in the Appearance page.
-    appearance_colored_header_label: Colored Header
-    appearance_colors_heading: Colors
-    appearance_colors_text: Choose two colors to theme your forum with. The first will be used as a highlight color, while the second will be used to style background elements.
-    appearance_custom_styles_heading: Custom Styles
-    appearance_custom_styles_text: Customize your forum's appearance by adding your own LESS/CSS code to be applied on top of Flarum's default styles.
-    appearance_dark_mode_label: Dark Mode
-    appearance_edit_css_button: Edit Custom CSS
-    appearance_enter_hex_message: Please enter a hexadecimal color code.
-    appearance_submit_button: => core.ref.save_changes
+    appearance:
+      colored_header_label: Colored Header
+      colors_heading: Colors
+      colors_text: Choose two colors to theme your forum with. The first will be used as a highlight color, while the second will be used to style background elements.
+      custom_styles_heading: Custom Styles
+      custom_styles_text: Customize your forum's appearance by adding your own LESS/CSS code to be applied on top of Flarum's default styles.
+      dark_mode_label: Dark Mode
+      edit_css_button: Edit Custom CSS
+      enter_hex_message: Please enter a hexadecimal color code.
+      submit_button: => core.ref.save_changes
 
     # These strings are used in the Basics page.
-    basics_all_discussions_label: => core.ref.all_discussions
-    basics_default_language_heading: Default Language
-    basics_forum_description_heading: Forum Description
-    basics_forum_description_text: Enter a short sentence or two that describes your community. This will appear in the meta tag and show up in search engines.
-    basics_forum_title_heading: Forum Title
-    basics_home_page_heading: Home Page
-    basics_home_page_text: Choose the page which users will first see when they visit your forum. If entering a custom value, use the path relative to the forum root.
-    basics_saved_message: Your changes were saved.
-    basics_submit_button: => core.ref.save_changes
-    basics_welcome_banner_heading: Welcome Banner
-    basics_welcome_banner_text: Configure the text that displays in the banner on the All Discussions page. Use this to welcome guests to your forum.
+    basics:
+      all_discussions_label: => core.ref.all_discussions
+      default_language_heading: Default Language
+      forum_description_heading: Forum Description
+      forum_description_text: Enter a short sentence or two that describes your community. This will appear in the meta tag and show up in search engines.
+      forum_title_heading: Forum Title
+      home_page_heading: Home Page
+      home_page_text: Choose the page which users will first see when they visit your forum. If entering a custom value, use the path relative to the forum root.
+      saved_message: Your changes were saved.
+      submit_button: => core.ref.save_changes
+      welcome_banner_heading: Welcome Banner
+      welcome_banner_text: Configure the text that displays in the banner on the All Discussions page. Use this to welcome guests to your forum.
 
     # These strings are used in the Dashboard page.
-    dashboard_beta_warning_text: "This <strong>beta software</strong> is provided primarily so that you can help us test it and make it better; it should not be used in production."
-    dashboard_contributing_text: "Want to look for bugs and contribute? Read the <a>Contributing docs</a>."
-    dashboard_extension_text: "Interested in developing extensions? Read the <a>Extension docs</a>."
-    dashboard_features_text: "Got an idea to improve a feature? Tell us about it under the <a>Features tag</a>."
-    dashboard_support_text: "Found a bug? Please report it in our forum, under the <a>Support tag</a>."
-    dashboard_troubleshooting_text: "Having problems? Follow the instructions in the <a>Troubleshooting docs</a>."
-    dashboard_version_text: "Thanks for trying out Flarum! You are running version {version}."
+    dashboard:
+      beta_warning_text: "This <strong>beta software</strong> is provided primarily so that you can help us test it and make it better; it should not be used in production."
+      contributing_text: "Want to look for bugs and contribute? Read the <a>Contributing docs</a>."
+      extension_text: "Interested in developing extensions? Read the <a>Extension docs</a>."
+      features_text: "Got an idea to improve a feature? Tell us about it under the <a>Features tag</a>."
+      support_text: "Found a bug? Please report it in our forum, under the <a>Support tag</a>."
+      troubleshooting_text: "Having problems? Follow the instructions in the <a>Troubleshooting docs</a>."
+      version_text: "Thanks for trying out Flarum! You are running version {version}."
 
     # These strings are used in the Edit Group modal dialog.
-    edit_group_color_label: Color
-    edit_group_delete_button: Delete Group
-    edit_group_delete_confirmation: Are you sure you want to delete this group? The group members will NOT be deleted.
-    edit_group_icon_label: Icon
-    edit_group_icon_text: "Enter the name of any <a>FontAwesome</a> icon class, <em>without</em> the <code>fa-</code> prefix."
-    edit_group_name_label: Name
-    edit_group_plural_placeholder: Plural (e.g. Mods)
-    edit_group_singular_placeholder: Singular (e.g. Mod)
-    edit_group_submit_button: => core.ref.save_changes
-    edit_group_title: Create Group
+    edit_group:
+      color_label: Color
+      delete_button: Delete Group
+      delete_confirmation: Are you sure you want to delete this group? The group members will NOT be deleted.
+      icon_label: Icon
+      icon_text: "Enter the name of any <a>FontAwesome</a> icon class, <em>without</em> the <code>fa-</code> prefix."
+      name_label: Name
+      plural_placeholder: Plural (e.g. Mods)
+      singular_placeholder: Singular (e.g. Mod)
+      submit_button: => core.ref.save_changes
+      title: Create Group
 
     # These strings are used in the Extensions page.
-    extensions_add_button: Add Extension
-    extensions_disable_button: Disable
-    extensions_enable_button: Enable
-    extensions_settings_button: => core.ref.settings
-    extensions_uninstall_button: Uninstall
-
-    # This string is used in the Extensions loading modal dialog.
-    extensions_loading_title: Please Wait...
+    extensions:
+      add_button: Add Extension
+      disable_button: Disable
+      enable_button: Enable
+      settings_button: => core.ref.settings
+      uninstall_button: Uninstall
 
     # This string is used in the session dropdown menu.
-    header_log_out_button: => core.ref.log_out
+    header:
+      log_out_button: => core.ref.log_out
+
+    # This string is used in the modal dialog displayed when loading extensions.
+    loading:
+      title: Please Wait...
 
     # These strings are used in the navigation bar.
-    nav_appearance_button: Appearance
-    nav_appearance_text: Customize your forum's colors, logos, and other variables.
-    nav_basics_button: Basics
-    nav_basics_text: Set your forum title, language, and other basic settings.
-    nav_dashboard_button: Dashboard
-    nav_dashboard_text: Your forum at a glance.
-    nav_extensions_button: Extensions
-    nav_extensions_text: Add extra functionality to your forum and make it your own.
-    nav_permissions_button: Permissions
-    nav_permissions_text: Configure who can see and do what.
+    nav:
+      appearance_button: Appearance
+      appearance_text: Customize your forum's colors, logos, and other variables.
+      basics_button: Basics
+      basics_text: Set your forum title, language, and other basic settings.
+      dashboard_button: Dashboard
+      dashboard_text: Your forum at a glance.
+      extensions_button: Extensions
+      extensions_text: Add extra functionality to your forum and make it your own.
+      permissions_button: Permissions
+      permissions_text: Configure who can see and do what.
 
     # These strings are used in the Permissions page of the admin interface.
-    permissions_allow_indefinitely_button: Indefinitely
-    permissions_allow_renaming_label: Allow renaming
-    permissions_allow_post_editing_label: Allow post editing
-    permissions_allow_some_minutes_button: "For {count} minute|For {count} minutes"
-    permissions_allow_ten_minutes_button: For 10 minutes
-    permissions_allow_until_reply_button: Until next reply
-    permissions_create_heading: Create
-    permissions_delete_discussions_forever_label: Delete discussions forever
-    permissions_delete_discussions_label: Delete discussions
-    permissions_delete_posts_forever_label: Delete posts forever
-    permissions_edit_and_delete_posts_label: Edit and delete posts
-    permissions_global_heading: Global
-    permissions_moderate_heading: Moderate
-    permissions_new_group_button: New Group
-    permissions_participate_heading: Participate
-    permissions_read_heading: Read
-    permissions_rename_discussions_label: Rename discussions
-    permissions_reply_to_discussions_label: Reply to discussions
-    permissions_signup_closed_button: Closed
-    permissions_signup_open_button: Open
-    permissions_sign_up_label: Sign up
-    permissions_start_discussions_label: Start discussions
-    permissions_view_discussions_label: View discussions
+    permissions:
+      allow_renaming_label: Allow renaming
+      allow_post_editing_label: Allow post editing
+      create_heading: Create
+      delete_discussions_forever_label: Delete discussions forever
+      delete_discussions_label: Delete discussions
+      delete_posts_forever_label: Delete posts forever
+      edit_and_delete_posts_label: Edit and delete posts
+      global_heading: Global
+      moderate_heading: Moderate
+      new_group_button: New Group
+      participate_heading: Participate
+      read_heading: Read
+      rename_discussions_label: Rename discussions
+      reply_to_discussions_label: Reply to discussions
+      sign_up_label: Sign up
+      start_discussions_label: Start discussions
+      view_discussions_label: View discussions
 
     # These strings are used in the dropdown menus on the Permissions page.
-    permissions_dropdown_everyone_button: Everyone
-    permissions_dropdown_members_button: Members
+    permissions_controls:
+      allow_indefinitely_button: Indefinitely
+      allow_some_minutes_button: "For {count} minute|For {count} minutes"
+      allow_ten_minutes_button: For 10 minutes
+      allow_until_reply_button: Until next reply
+      everyone_button: Everyone
+      members_button: => core.groups.members
+      signup_closed_button: Closed
+      signup_open_button: Open
+
+  # Strings in this namespace are used by the forum user interface.
+  forum:
+
+    # These strings are used in the Change Email modal dialog.
+    change_email:
+      confirmation_message: => core.ref.confirmation_email_sent
+      dismiss_button: => core.ref.okay
+      submit_button: => core.ref.save_changes
+      title: => core.ref.change_email
+
+    # These strings are used in the Change Password modal dialog.
+    change_password:
+      send_button: Send Password Reset Email
+      text: Click the button below and check your email for a link to change your password.
+      title: => core.ref.change_password
+
+    # These strings are used by the composer controls.
+    composer:
+      close_tooltip: Close
+      exit_full_screen_tooltip: Exit Full Screen
+      full_screen_tooltip: Full Screen
+      minimize_tooltip: Minimize
+
+    # These strings are used by the composer when starting a discussion.
+    composer_discussion:
+      body_placeholder: Write a Post...
+      discard_confirmation: You have not posted your discussion. Do you wish to discard it?
+      submit_button: Post Discussion
+      title_placeholder: Discussion Title
+
+    # These strings are used by the composer when editing a post.
+    composer_edit:
+      discard_confirmation: You have not saved your changes. Do you wish to discard them?
+      post_link: "Post #{number} in {discussion}"
+      submit_button: => core.ref.save_changes
+
+    # These strings are used by the composer when replying to a discussion.
+    composer_reply:
+      body_placeholder: => core.ref.write_a_reply
+      discard_confirmation: You have not posted your reply. Do you wish to discard it?
+      posted_message: Your reply was posted.
+      submit_button: Post Reply
+      view_button: View
+
+    # These strings are used by the discussion control buttons.
+    discussion_controls:
+      cannot_reply_button: Can't Reply
+      cannot_reply_text: You don't have permission to reply to this discussion.
+      delete_button: => core.ref.delete
+      delete_confirmation: Are you sure you want to delete this discussion?
+      delete_forever_button: => core.ref.delete_forever
+      log_in_to_reply_button: Log In to Reply
+      rename_button: Rename
+      rename_text: Enter a new title for this discussion:
+      reply_button: Reply
+      restore_button: => core.ref.restore
+
+    # These strings are used in the discussion list.
+    discussion_list:
+      empty_text: Looks like there are no discussions here. Why don't you create a new one?
+      load_more_button: => core.ref.load_more
+      mark_as_read_tooltip: Mark as Read
+      replied_text: "{username} replied {ago}"
+      started_text: "{username} started {ago}"
+
+    # These strings are used in the Edit User modal dialog (admin function).
+    edit_user:
+      email_label: => core.ref.email
+      password_label: => core.ref.password
+      submit_button: => core.ref.save_changes
+      username_label: => core.ref.username
+
+    # These strings are used in the Forgot Password modal dialog.
+    forgot_password:
+      dismiss_button: => core.ref.okay
+      email_placeholder: => core.ref.email
+      email_sent_message: We've sent you an email containing a link to reset your password. Check your spam folder if you don't receive it within the next minute or two.
+      submit_button: Recover Password
+      text: Enter your email address and we will send you a link to reset your password.
+      title: Forgot Password
+
+    # These strings are used in the header and session dropdown menu.
+    header:
+      admin_button: Administration
+      log_in_link: => core.ref.log_in
+      log_out_button: => core.ref.log_out
+      profile_button: Profile
+      search_placeholder: Search Forum
+      settings_button: => core.ref.settings
+      sign_up_link: => core.ref.sign_up
+
+    # These strings are used on the index page, peripheral to the discussion list.
+    index:
+      all_discussions_link: => core.ref.all_discussions
+      cannot_start_discussion_button: Can't Start Discussion
+      mark_all_as_read_tooltip: => core.ref.mark_all_as_read
+      refresh_tooltip: Refresh
+      start_discussion_button: Start a Discussion
+
+    # These strings are used by the sorting control above the discussion list.
+    index_sort:
+      latest_button: Latest
+      newest_button: Newest
+      oldest_button: Oldest
+      relevance_button: Relevance
+      top_button: Top
+
+    # These strings are used in the Log In modal dialog.
+    log_in:
+      confirmation_required_message: "You need to confirm your email before you can log in. We've sent a confirmation email to {email}. If it doesn't arrive soon, check your spam folder."
+      forgot_password_link: Forgot password?
+      invalid_login_message: Your login details were incorrect.
+      password_placeholder: => core.ref.password
+      sign_up_text: "Don't have an account? <a>Sign Up</a>"
+      submit_button: => core.ref.log_in
+      title: => core.ref.log_in
+      username_or_email_placeholder: Username or Email
+
+    # These strings are used by the Notifications dropdown, a.k.a. "the bell".
+    notifications:
+      discussion_renamed_text: "{username} changed the title"
+      empty_text: No Notifications
+      mark_all_as_read_tooltip: => core.ref.mark_all_as_read
+      title: => core.ref.notifications
+      tooltip: => core.ref.notifications
+
+    # These strings are used by tooltips displayed for individual posts.
+    post:
+      edited_tooltip: "{username} edited {ago}"
+      number_tooltip: "Post #{number}"
+
+    # These strings are used by the post control buttons.
+    post_controls:
+      delete_button: => core.ref.delete
+      delete_forever_button: => core.ref.delete_forever
+      edit_button: => core.ref.edit
+      restore_button: => core.ref.restore
+
+    # These strings are used in the scrubber to the right of the post stream.
+    post_scrubber:
+      now_link: Now
+      original_post_link: Original Post
+      unread_text: "{count} unread"
+      viewing_text: "{index} of {count} post|{index} of {count} posts"
+
+    # These strings are displayed between posts in the post stream.
+    post_stream:
+      discussion_renamed_text: "{username} changed the title from {old} to {new}."
+      reply_placeholder: => core.ref.write_a_reply
+      time_lapsed_text: "{period} later"
+
+    # These strings are used by the search results dropdown list.
+    search:
+      all_discussions_button: 'Search all discussions for "{query}"'
+      discussions_heading: => core.ref.discussions
+      users_heading: Users
+
+    # These strings are used in the Settings page.
+    settings:
+      account_heading: Account
+      change_email_button: => core.ref.change_email
+      change_password_button: => core.ref.change_password
+      notifications_heading: => core.ref.notifications
+      notify_by_email_heading: => core.ref.email
+      notify_by_web_heading: Web
+      notify_discussion_renamed_label: Someone renames a discussion I started
+      privacy_disclose_online_label: Allow others to see when I am online
+      privacy_heading: Privacy
+      title: => core.ref.settings
+
+    # These strings are used in the Sign Up modal dialog.
+    sign_up:
+      confirmation_message: => core.ref.confirmation_email_sent
+      email_placeholder: => core.ref.email
+      dismiss_button: => core.ref.okay
+      log_in_text: "Already have an account? <a>Log In</a>"
+      password_placeholder: => core.ref.password
+      submit_button: => core.ref.sign_up
+      title: => core.ref.sign_up
+      username_placeholder: => core.ref.username
+      welcome_text: "Welcome, {username}!"
+
+    # These strings are used in the user profile page and profile popup.
+    user:
+      avatar_remove_button: Remove
+      avatar_upload_button: Upload
+      bio_placeholder: Write something about yourself
+      discussions_link: => core.ref.discussions
+      joined_date_text: "Joined {ago}"
+      online_text: Online
+      posts_load_more_button: => core.ref.load_more
+      posts_link: Posts
+      settings_link: => core.ref.settings
+
+    # These strings are found on the user profile page (admin function).
+    user_controls:
+      button: Controls
+      delete_button: => core.ref.delete
+      delete_confirmation: Are you sure you want to delete this user? All of the user's posts will be deleted.
+      edit_button: => core.ref.edit
 
   # Strings in this namespace are used by the forum and admin interfaces.
   lib:
 
+    # This string is displayed in place of the username of deleted user account.
+    deleted_user_text: "[deleted]"
+
+    # This string is displayed as the tooltip for the badge on a soft-deleted discussion.
+    hidden_discussion_tooltip: Hidden
+
+    # This string is displayed when an error occurs.
+    oops_message: Oops! Something went wrong. Please reload the page and try again.
+
     # These strings are used to punctuate a series of items.
-    series_glue_text: ", "
-    series_two_text: "{first} and {second}"
-    series_three_text: "{first}, {second}, and {third}"
+    series:
+      glue_text: ", "
+      two_text: "{first} and {second}"
+      three_text: "{first}, {second}, and {third}"
+
+    #These strings are used as suffixes when abbreviating numbers.
+    suffix:
+      kilo_text: K
+      mega_text: M
 
   ##
-  # REUSED STRINGS - The following keys are referenced by two or more unique keys.
+  # REUSED STRINGS - These keys should not be used directly in code!
   ##
 
+  # Strings in this namespace are referenced by two or more unique keys.
   ref:
     all_discussions: All Discussions
     change_email: Change Email
@@ -325,20 +370,13 @@ core:
     write_a_reply: Write a Reply...
 
   ##
-  # DEFAULT GROUP NAMES - Translations for the forum's default language are used.
+  # EMAIL CONTENT
   ##
 
-  group:
-    admin: Admin
-    admins: Admins
-    guest: Guest
-    guests: Guests
-    member: Member
-    members: Members
-    mod: Mod
-    mods: Mods
-
+  # Strings in this namespace are used in emails sent by the forum.
   email:
+
+    # These strings are used in emails sent when users register new accounts.
     activate_account:
       subject: Activate Your New Account
       body: |
@@ -351,6 +389,7 @@ core:
 
         If you did not sign up, please ignore this email.
 
+    # These strings are used in emails sent when users change their email address.
     confirm_email:
       subject: Confirm Your New Email Address
       body: |
@@ -363,6 +402,7 @@ core:
 
         If this was not you, please ignore this email.
 
+    # These strings are used in emails sent when users ask to reset their passwords.
     reset_password:
       subject: Reset Your Password
       body: |
@@ -374,3 +414,19 @@ core:
         {url}
 
         If you do not wish to change your password, just ignore this email and nothing will happen.
+
+  ##
+  # GROUP NAMES
+  ##
+
+  # Strings in this namespace are used to translate default group names.
+  group:
+    admin: Admin
+    admins: Admins
+    guest: Guest
+    guests: Guests
+    member: Member
+    members: Members
+    mod: Mod
+    mods: Mods
+


### PR DESCRIPTION
- Adds new sub-keys to replace key prefixes, and adjusts key names accordingly.
- Moves several button strings from `admin.permissions_` to `admin.permissions_controls`
- Merges `forum.settings_notify_` strings into `forum.settings`
- Rolls `forum.user_avatar_` strings into `forum.user`
- Moves the `user_deleted_text` to the `lib` namespace.
- Adds four other leftover strings to the `lib` namespace.
- Includes minor changes to formatting and comments.