### PR TITLE
Reorganize key names for Flags

### DIFF
--- a/locale/flarum-flags.yml
+++ b/locale/flarum-flags.yml
@@ -1,9 +1,50 @@
 flarum-flags:
+
+  ##
+  # UNIQUE KEYS - The following keys are used in only one location each.
+  ##
+
+  # Strings in this namespace are used by the admin interface.
+  admin:
+
+    # These strings are used in the Permissions page of the admin interface.
+    permissions:
+      flag_posts: Flag posts
+      view_flags: View flagged posts
+
+  # Strings in this namespace are used by the forum user interface.
   forum:
-    reason_off_topic: Off-topic
-    reason_spam: Spam
-    reason_inappropriate: Inappropriate
-    reason_other: Other
-    flagged_by: "{username} flagged"
-    flagged_by_with_reason: "{username} flagged as {reason}"
-    no_flags: No Flags
+
+    # These strings are used by the Flag Post modal dialog.
+    flag_post:
+      reason_heading: Choose a Reason
+      reason_inappropriate_label: Inappropriate
+      reason_off_topic_label: Off-topic
+      reason_other_label: Other
+      reason_spam_label: Spam
+      submit_button: => flarum-flags.ref.flag_post
+      title: => flarum-flags.ref.flag_post
+
+    # These strings are used by the Flagged Posts dropdown, a.k.a. "the flag".
+    flagged_posts:
+      no_flags: No Flags
+      title: => flarum-flags.ref.flagged_posts
+      tooltip: => flarum-flags.ref.flagged_posts
+
+    # These strings are used by the frame displayed around flagged posts.
+    post:
+      dismiss_flag_tooltip: Dismiss Flag
+      flagged_by: "{username} flagged"
+      flagged_by_with_reason: "{username} flagged as {reason}"
+
+    # These strings are used by the post control buttons.
+    post_controls:
+      flag_button: Flag
+
+  ##
+  # REUSED STRINGS - The following keys are referenced by two or more unique keys.
+  ##
+
+  ref:
+    flag_post: Flag Post
+    flagged_posts: Flagged Posts


### PR DESCRIPTION
See [flarum/core #265](https://github.com/flarum/core/issues/265)

- Adjusts key names to three-tier namespacing.
- Adds newly extracted strings.
- Adds commenting to match core.

Please don't merge! Will be adding further commits.