### PR TITLE
Reorganize key names for Lock

### DIFF
--- a/locale/flarum-lock.yml
+++ b/locale/flarum-lock.yml
@@ -1,9 +1,37 @@
 flarum-lock:
+
+  ##
+  # UNIQUE KEYS - The following keys are used in only one location each.
+  ##
+
+  # Strings in this namespace are used by the admin interface.
+  admin:
+
+    # These strings are used in the Permissions page of the admin interface.
+    permissions:
+      lock_discussions_label: Lock discussions
+
+  # Strings in this namespace are used by the forum user interface.
   forum:
-    discussion_locked_notification: "{username} locked"
-    discussion_locked_post: "{username} locked the discussion."
-    discussion_unlocked_post: "{username} unlocked the discussion."
-    notify_discussion_locked: Someone locks a discussion I started
-    locked: Locked
-    lock: Lock
-    unlock: Unlock
+
+    # These strings are displayed as tooltips for discussion badges.
+    badge:
+      locked_discussion_tooltip: Locked
+
+    # These strings are used by the discussion control buttons.
+    discussion_controls:
+      lock: Lock
+      unlock: Unlock
+
+    # These strings are used by the Notifications dropdown, a.k.a. "the bell".
+    notifications:
+      discussion_locked_notification: "{username} locked"
+
+    post_stream:
+      discussion_locked_post: "{username} locked the discussion."
+      discussion_unlocked_post: "{username} unlocked the discussion."
+
+    # These strings are used in the Settings page.
+    settings:
+      notify_discussion_locked_label: Someone locks a discussion I started
+


### PR DESCRIPTION
See [flarum/core #265](https://github.com/flarum/core/issues/265).

- Adjusts key names to three-tier namespacing.
- Adds newly extracted strings.
- Adds commenting to match core.