### PR TITLE
Rename keys for badge tooltips

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -322,7 +322,7 @@ core:
 
     # These strings are displayed as tooltips for discussion badges.
     badge:
-      hidden_discussion_tooltip: Hidden
+      hidden_tooltip: Hidden
 
     # This string is displayed in place of the username of deleted user account.
     deleted_user_text: "[deleted]"

--- a/locale/flarum-lock.yml
+++ b/locale/flarum-lock.yml
@@ -16,7 +16,7 @@ flarum-lock:
 
     # These strings are displayed as tooltips for discussion badges.
     badge:
-      locked_discussion_tooltip: Locked
+      locked_tooltip: Locked
 
     # These strings are used by the discussion control buttons.
     discussion_controls:


### PR DESCRIPTION
- Shortens two key names for consistency with `badge:` namespace.
- Supports https://github.com/flarum/core/pull/601
- Supports https://github.com/flarum/lock/pull/4