### PR TITLE
Reorganize key names for Subscriptions

### DIFF
--- a/locale/flarum-subscriptions.yml
+++ b/locale/flarum-subscriptions.yml
@@ -1,14 +1,51 @@
 flarum-subscriptions:
+
+  ##
+  # UNIQUE KEYS - The following keys are used in only one location each.
+  ##
+
+  # Strings in this namespace are used by the forum user interface.
   forum:
+
+    # These strings are displayed as tooltips for discussion badges.
+    badge:
+      following_tooltip: => flarum-subscriptions.ref.following
+      ignoring_tooltip: => flarum-subscriptions.ref.ignoring
+
+    # These strings are used by the discussion control buttons.
+    discussion_controls:
+      follow_button: => flarum-subscriptions.ref.follow
+      unfollow_button: Unfollow
+      unignore_button: Unignore
+
+    # These strings are used on the index page, peripheral to the discussion list.
+    index:
+      following_link: => flarum-subscriptions.ref.following
+
+    # These strings are used by the Notifications dropdown, a.k.a. "the bell".
+    notifications:
+      new_post_text: "{username} posted"
+
+    # These strings are used in the Settings page.
+    settings:
+      notify_new_post_label: Someone posts in a discussion I'm following
+
+    # These strings are used in the subscription menu displayed to the right of the post stream.
+    sub_controls:
+      follow_button: => flarum-subscriptions.ref.follow
+      following_button: => flarum-subscriptions.ref.following
+      following_text: Be notified of all replies.
+      ignoring_button: => flarum-subscriptions.ref.ignoring
+      ignoring_text: Never be notified. Hide from the discussion list.
+      not_following_button: Not Following
+      not_following_text: Be notified when @mentioned.
+
+  ##
+  # REUSED STRINGS - These keys should not be used directly in code!
+  ##
+
+  # Strings in this namespace are referenced by two or more unique keys.
+  ref:
+    follow: Follow
     following: Following
     ignoring: Ignoring
-    follow: Follow
-    unfollow: Unfollow
-    ignore: Ignore
-    notify_new_post: Someone posts in a discussion I'm following
-    new_post_notification: "{username} posted"
-    not_following: Not Following
-    not_following_description: Be notified when @mentioned.
-    following_description: Be notified of all replies.
-    ignoring_description: Never be notified. Hide from the discussion list.
-    unignore: Unignore


### PR DESCRIPTION
See [flarum/core #265](https://github.com/flarum/core/issues/265).

- Adjusts key names to three-tier namespacing.
- Adds newly extracted strings.
- Adds commenting to match core.