### PR TITLE
Revise "reused strings" commenting to match core

### DIFF
--- a/locale/flarum-flags.yml
+++ b/locale/flarum-flags.yml
@@ -42,9 +42,10 @@ flarum-flags:
       flag_button: Flag
 
   ##
-  # REUSED STRINGS - The following keys are referenced by two or more unique keys.
+  # REUSED STRINGS - These keys should not be used directly in code!
   ##
 
+  # Strings in this namespace are referenced by two or more unique keys.
   ref:
     flag_post: Flag Post
     flagged_posts: Flagged Posts

--- a/locale/flarum-sticky.yml
+++ b/locale/flarum-sticky.yml
@@ -29,8 +29,9 @@ flarum-sticky:
       discussion_unstickied_text: "{username} unstickied the discussion."
 
   ##
-  # REUSED STRINGS - The following keys are referenced by two or more unique keys.
+  # REUSED STRINGS - These keys should not be used directly in code!
   ##
 
+  # Strings in this namespace are referenced by two or more unique keys.
   ref:
     sticky: Sticky


### PR DESCRIPTION
- Fixes commenting on two files where I accidentally used an old version.