### PR TITLE
Reorganize key names for Tags

### DIFF
--- a/locale/flarum-subscriptions.yml
+++ b/locale/flarum-subscriptions.yml
@@ -38,7 +38,7 @@ flarum-subscriptions:
       ignoring_button: => flarum-subscriptions.ref.ignoring
       ignoring_text: Never be notified. Hide from the discussion list.
       not_following_button: Not Following
-      not_following_text: Be notified when @mentioned.
+      not_following_text: Be notified only when @mentioned.
 
   ##
   # REUSED STRINGS - These keys should not be used directly in code!

--- a/locale/flarum-tags.yml
+++ b/locale/flarum-tags.yml
@@ -1,15 +1,100 @@
 flarum-tags:
+
+  ##
+  # UNIQUE KEYS - The following keys are used in only one location each.
+  ##
+
+  # Strings in this namespace are used by the admin interface.
+  admin:
+
+    # These strings are used in the Basics page.
+    basics:
+      tags_label: => flarum-tags.ref.tags
+
+    # These strings are used in the Edit Tag modal dialog.
+    edit_tag:
+      color_label: Color
+      description_label: Description
+      delete_tag_button: Delete Tag
+      delete_tag_confirmation: Are you sure you want to delete this tag? The tag's discussions will NOT be deleted.
+      hide_label: Hide from All Discussions
+      name_label: => flarum-tags.ref.name
+      name_placeholder: => flarum-tags.ref.name
+      slug_label: Slug
+      submit_button: => core.ref.save_changes
+      title: => flarum-tags.ref.create_tag
+
+    # These strings are used in the navigation bar.
+    nav:
+      tags_button: => flarum-tags.ref.tags
+      tags_text: Manage the list of tags available to organise discussions with.
+
+    # These strings are used in the Permissions page of the admin interface.
+    permissions:
+      restrict_by_tag_heading: Restrict by Tag
+      tag_discussions_label: Tag discussions
+
+    # These strings are used in the Tag Settings modal dialog.
+    tag_settings:
+      range_separator_text: " to "
+      required_primary_heading: Required Number of Primary Tags
+      required_primary_text: Enter the minimum and maximum number of primary tags that may be applied to a discussion.
+      required_secondary_heading: Required Number of Secondary Tags
+      required_secondary_text: Enter the minimum and maximum number of secondary tags that may be applied to a discussion.
+      title: Tag Settings
+
+    # These strings are used in the Tags page.
+    tags:
+      about_tags_text: Tags are used to categorize discussions. Primary tags are like traditional forum categories: they can be arranged in a two-level hierarchy. Secondary tags do not have hierarchy or order, and are useful for micro-categorization.
+      create_tag_button: => flarum-tags.ref.create_tag
+      primary_heading: Primary Tags
+      secondary_heading: Secondary Tags
+      settings_button: Settings
+
+  # Strings in this namespace are used by the forum user interface.
   forum:
+
+    # These strings are used by the Choose Tags modal dialog.
+    choose_tags:
+      choose_primary_placeholder: "Choose a primary tag|Choose {count} primary tags"
+      choose_secondary_placeholder: "Choose 1 more tag|Choose {count} more tags"
+      edit_title: "Edit Tags for {title}"
+      submit_button: Confirm
+      title: Choose Tags for Your Discussion
+
+    # These strings are used by the composer when starting a discussion.
+    composer_discussion:
+      choose_tags_link: Choose Tags
+
+    # These strings are used by the discussion control buttons.
+    discussion_controls:
+      edit_tags_button: Edit Tags
+
+    # These strings are used on the index page, peripheral to the discussion list.
+    index:
+      tags_link: => flarum-tags.ref.tags
+      more_link: More...
+      untagged_link: Untagged
+
+    # These strings are displayed between posts in the post stream.
+    post_stream:
+      added_tags_text: "{username} added the {tagsAdded}."
+      added_and_removed_tags_text: "{username} added the {tagsAdded} and removed the {tagsRemoved}."
+      removed_tags_text: "{username} removed the {tagsRemoved}."
+      tags_text: "{tags} tag|{tags} tags"
+
+  # Strings in this namespace are used by the forum and admin interfaces.
+  lib:
+
+    # This string is displayed in place of the name of a tag that's been deleted.
+    deleted_tag_text: Deleted
+
+  ##
+  # REUSED STRINGS - These keys should not be used directly in code!
+  ##
+
+  # Strings in this namespace are referenced by two or more unique keys.
+  ref:
+    create_tag: Create Tag
+    name: Name
     tags: Tags
-    discussion_tagged_post: "{username} {action} tag.|{username} {action} tags."
-    added_tags: "added the {tags}"
-    removed_tags: "removed the {tags}"
-    tag_new_discussion_title: Choose Tags for Your Discussion
-    tag_new_discussion_link: Choose Tags
-    edit_discussion_tags_title: "Edit Tags for {title}"
-    edit_discussion_tags_link: Edit Tags
-    choose_primary_tags: "Choose a primary tag|Choose {count} primary tags"
-    choose_secondary_tags: "Choose 1 more tag|Choose {count} more tags"
-    confirm: Confirm
-    more: More...
-    deleted: Deleted


### PR DESCRIPTION
See [flarum/core #265](https://github.com/flarum/core/issues/265).

- Adjusts key names to three-tier namespacing.
- Adds newly extracted strings.
- Adds commenting to match core.
- Supports https://github.com/flarum/tags/pull/22.
- (Also adjusts one string in **flarum-subscriptions.yml**.)