### PR TITLE
Reorganize key names for Mentions

### DIFF
--- a/locale/flarum-mentions.yml
+++ b/locale/flarum-mentions.yml
@@ -1,11 +1,39 @@
 flarum-mentions:
+
+  ##
+  # UNIQUE KEYS - The following keys are used in only one location each.
+  ##
+
+  # Strings in this namespace are used by the forum user interface.
   forum:
-    reply_to_post: "Reply to #{number}"
-    post_mentioned_notification: "{username} replied to your post"
+
+    # These strings are used by the composer (reply autocompletion function).
+    composer:
+      reply_to_post_text: "Reply to #{number}"
+
+    # These strings are used by the Notifications dropdown, a.k.a. "the bell".
+    notifications:
+      post_mentioned_text: "{username} replied to your post"
+      others_text: => flarum-mentions.ref.others
+      user_mentioned_text: "{username} mentioned you"
+
+    # These strings are displayed beneath individual posts.
+    post:
+      mentioned_by_text: "{users} replied to this."       # Can be pluralized to agree with the number of users!
+      mentioned_by_self_text: "{users} replied to this."  # Can be pluralized to agree with the number of users!
+      others_link: => flarum-mentions.ref.others
+      reply_link: Reply
+      you_text: You
+
+    # These strings are used in the Settings page.
+    settings:
+      notify_post_mentioned_label: Someone replies to my post
+      notify_user_mentioned_label: Someone mentions me in a post
+
+  ##
+  # REUSED STRINGS - These keys should not be used directly in code!
+  ##
+
+  # Strings in this namespace are referenced by two or more unique keys.
+  ref:
     others: "{count} others"
-    user_mentioned_notification: "{username} mentioned you"
-    post_mentioned_by: "{users} replied to this."
-    you: You
-    reply_link: Reply
-    notify_post_mentioned: Someone replies to my post
-    notify_user_mentioned: Someone mentions me in a post


### PR DESCRIPTION
See [flarum/core #265](https://github.com/flarum/core/issues/265).

- Adjusts key names to three-tier namespacing.
- Adds newly extracted strings.
- Adds commenting to match core.
- Adds comments to indicate pluralizable strings.
- Supports https://github.com/flarum/mentions/pull/12.