### PR TITLE
Merge Reply references into a reused string

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -170,7 +170,7 @@ core:
       log_in_to_reply_button: Log In to Reply
       rename_button: Rename
       rename_text: Enter a new title for this discussion:
-      reply_button: Reply
+      reply_button: => core.ref.reply
       restore_button: => core.ref.restore
 
     # These strings are used in the discussion list.
@@ -374,6 +374,7 @@ core:
     notifications: Notifications
     okay: OK
     password: Password
+    reply: Reply
     restore: Restore
     save_changes: Save Changes
     settings: Settings

--- a/locale/flarum-mentions.yml
+++ b/locale/flarum-mentions.yml
@@ -22,7 +22,7 @@ flarum-mentions:
       mentioned_by_text: "{users} replied to this."       # Can be pluralized to agree with the number of users!
       mentioned_by_self_text: "{users} replied to this."  # Can be pluralized to agree with the number of users!
       others_link: => flarum-mentions.ref.others
-      reply_link: Reply
+      reply_link: => core.ref.reply
       you_text: You
 
     # These strings are used in the Settings page.


### PR DESCRIPTION
Two strings use *Reply*, it's not necessary to translate it twice.

The addition of the newly `core.ref.reply` reused string fix that.