### PR TITLE
Merge reused strings into core

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -374,13 +374,15 @@ core:
     notifications: Notifications
     okay: OK
     password: Password
-    reply: Reply
+    reply: Reply                                 # Referenced by flarum-mentions.yml
     restore: Restore
-    save_changes: Save Changes
+    save_changes: Save Changes                   # Referenced by flarum-tags.yml
     settings: Settings
     sign_up: Sign Up
+    some_others: "{count} other|{count} others"  # Referenced by flarum-likes.yml, flarum-mentions.yml
     username: Username
     write_a_reply: Write a Reply...
+    you: You                                     # Referenced by flarum-likes.yml, flarum-mentions.yml
 
   ##
   # EMAIL CONTENT

--- a/locale/flarum-likes.yml
+++ b/locale/flarum-likes.yml
@@ -23,9 +23,9 @@ flarum-likes:
       like_link: Like
       liked_by_text: "{users} likes this.|{users} like this."
       liked_by_self_text: "{users} like this."  # Can be pluralized to agree with the number of users!
-      others_link: "{count} others"
+      others_link: => core.ref.some_others
       unlike_link: Unlike
-      you_text: You
+      you_text: => core.ref.you
 
     # These strings are used by the Users Who Like This modal dialog.
     post_likes:

--- a/locale/flarum-mentions.yml
+++ b/locale/flarum-mentions.yml
@@ -14,26 +14,18 @@ flarum-mentions:
     # These strings are used by the Notifications dropdown, a.k.a. "the bell".
     notifications:
       post_mentioned_text: "{username} replied to your post"
-      others_text: => flarum-mentions.ref.others
+      others_text: => core.ref.some_others
       user_mentioned_text: "{username} mentioned you"
 
     # These strings are displayed beneath individual posts.
     post:
       mentioned_by_text: "{users} replied to this."       # Can be pluralized to agree with the number of users!
       mentioned_by_self_text: "{users} replied to this."  # Can be pluralized to agree with the number of users!
-      others_link: => flarum-mentions.ref.others
+      others_text: => core.ref.some_others
       reply_link: => core.ref.reply
-      you_text: You
+      you_text: => core.ref.you
 
     # These strings are used in the Settings page.
     settings:
       notify_post_mentioned_label: Someone replies to one of my posts
       notify_user_mentioned_label: Someone mentions me in a post
-
-  ##
-  # REUSED STRINGS - These keys should not be used directly in code!
-  ##
-
-  # Strings in this namespace are referenced by two or more unique keys.
-  ref:
-    others: "{count} others"


### PR DESCRIPTION
- Merges two strings from Likes and Mentions into the core YML.
- Adds commenting to core YML to indicate strings referenced by extensions.
- Changes `others_link` to `others_text` in Mentions.
- Removes obsolete `ref:` namespace from Mentions.