### PR TITLE
Pluralize the post mentioned notification string

### DIFF
--- a/locale/flarum-mentions.yml
+++ b/locale/flarum-mentions.yml
@@ -13,7 +13,7 @@ flarum-mentions:
 
     # These strings are used by the Notifications dropdown, a.k.a. "the bell".
     notifications:
-      post_mentioned_text: "{username} replied to your post"
+      post_mentioned_text: "{username} replied to your post"  # Can be pluralized to agree with the number of users!
       others_text: => flarum-mentions.ref.others
       user_mentioned_text: "{username} mentioned you"
 


### PR DESCRIPTION
- Adds a comment to indicate a pluralizable string.
- Supports https://github.com/flarum/mentions/pull/13.