### PR TITLE
Pluralize the post liked notification string

### DIFF
--- a/locale/flarum-likes.yml
+++ b/locale/flarum-likes.yml
@@ -16,7 +16,7 @@ flarum-likes:
 
     # These strings are used by the Notifications dropdown, a.k.a. "the bell".
     notifications:
-      post_liked_text: "{username} liked your post"
+      post_liked_text: "{username} liked your post"  # Can be pluralized to agree with the number of users!
       others_text: => core.ref.some_others
 
     # These strings are displayed beneath individual posts.


### PR DESCRIPTION
- Adds a comment to indicate a pluralizable string.
- Supports https://github.com/flarum/likes/commit/e867b54.