### PR TITLE
Add Flarum's Core as a requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,9 @@
     "description": "English language pack.",
     "keywords": ["locale"],
     "license": "MIT",
+    "require": {
+        "flarum/core": "^0.1.0-beta.4"
+    },
     "extra": {
         "flarum-extension": {
             "title": "English",


### PR DESCRIPTION
The English language pack is for Flarum and can't be used without it, so I don't see why to not add Flarum's Core as requirement, as extensions.