### PR TITLE
Reorder second-tier keys

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -4,10 +4,10 @@ core:
   # UNIQUE KEYS - The following keys are used in only one location each.
   ##
 
-  # Strings in this namespace are used by the admin interface.
+  # Translations in this namespace are used by the admin interface.
   admin:
 
-    # These strings are used in the Appearance page.
+    # These translations are used in the Appearance page.
     appearance:
       colored_header_label: Colored Header
       colors_heading: Colors
@@ -19,7 +19,7 @@ core:
       enter_hex_message: Please enter a hexadecimal color code.
       submit_button: => core.ref.save_changes
 
-    # These strings are used in the Basics page.
+    # These translations are used in the Basics page.
     basics:
       all_discussions_label: => core.ref.all_discussions
       default_language_heading: Default Language
@@ -33,7 +33,7 @@ core:
       welcome_banner_heading: Welcome Banner
       welcome_banner_text: Configure the text that displays in the banner on the All Discussions page. Use this to welcome guests to your forum.
 
-    # These strings are used in the Dashboard page.
+    # These translations are used in the Dashboard page.
     dashboard:
       beta_warning_text: "This <strong>beta software</strong> is provided primarily so that you can help us test it and make it better; it should not be used in production."
       contributing_text: "Want to look for bugs and contribute? Read the <a>Contributing docs</a>."
@@ -43,7 +43,7 @@ core:
       troubleshooting_text: "Having problems? Follow the instructions in the <a>Troubleshooting docs</a>."
       version_text: "Thanks for trying out Flarum! You are running version {version}."
 
-    # These strings are used in the Edit Group modal dialog.
+    # These translations are used in the Edit Group modal dialog.
     edit_group:
       color_label: Color
       delete_button: Delete Group
@@ -56,7 +56,7 @@ core:
       submit_button: => core.ref.save_changes
       title: Create Group
 
-    # These strings are used in the Extensions page.
+    # These translations are used in the Extensions page.
     extensions:
       add_button: Add Extension
       disable_button: Disable
@@ -72,7 +72,7 @@ core:
     loading:
       title: Please Wait...
 
-    # These strings are used in the navigation bar.
+    # These translations are used in the navigation bar.
     nav:
       appearance_button: Appearance
       appearance_text: "Customize your forum's colors, logos, and other variables."
@@ -85,7 +85,7 @@ core:
       permissions_button: Permissions
       permissions_text: Configure who can see and do what.
 
-    # These strings are used in the Permissions page of the admin interface.
+    # These translations are used in the Permissions page of the admin interface.
     permissions:
       allow_renaming_label: Allow renaming
       allow_post_editing_label: Allow post editing
@@ -105,7 +105,7 @@ core:
       start_discussions_label: Start discussions
       view_discussions_label: View discussions
 
-    # These strings are used in the dropdown menus on the Permissions page.
+    # These translations are used in the dropdown menus on the Permissions page.
     permissions_controls:
       allow_indefinitely_button: Indefinitely
       allow_some_minutes_button: "For {count} minute|For {count} minutes"
@@ -116,43 +116,43 @@ core:
       signup_closed_button: Closed
       signup_open_button: Open
 
-  # Strings in this namespace are used by the forum user interface.
+  # Translations in this namespace are used by the forum user interface.
   forum:
 
-    # These strings are used in the Change Email modal dialog.
+    # These translations are used in the Change Email modal dialog.
     change_email:
       confirmation_message: => core.ref.confirmation_email_sent
       dismiss_button: => core.ref.okay
       submit_button: => core.ref.save_changes
       title: => core.ref.change_email
 
-    # These strings are used in the Change Password modal dialog.
+    # These translations are used in the Change Password modal dialog.
     change_password:
       send_button: Send Password Reset Email
       text: Click the button below and check your email for a link to change your password.
       title: => core.ref.change_password
 
-    # These strings are used by the composer controls.
+    # These translations are used by the composer controls.
     composer:
       close_tooltip: Close
       exit_full_screen_tooltip: Exit Full Screen
       full_screen_tooltip: Full Screen
       minimize_tooltip: Minimize
 
-    # These strings are used by the composer when starting a discussion.
+    # These translations are used by the composer when starting a discussion.
     composer_discussion:
       body_placeholder: Write a Post...
       discard_confirmation: "You have not posted your discussion. Do you wish to discard it?"
       submit_button: Post Discussion
       title_placeholder: Discussion Title
 
-    # These strings are used by the composer when editing a post.
+    # These translations are used by the composer when editing a post.
     composer_edit:
       discard_confirmation: "You have not saved your changes. Do you wish to discard them?"
       post_link: "Post #{number} in {discussion}"
       submit_button: => core.ref.save_changes
 
-    # These strings are used by the composer when replying to a discussion.
+    # These translations are used by the composer when replying to a discussion.
     composer_reply:
       body_placeholder: => core.ref.write_a_reply
       discard_confirmation: "You have not posted your reply. Do you wish to discard it?"
@@ -160,7 +160,7 @@ core:
       submit_button: Post Reply
       view_button: View
 
-    # These strings are used by the discussion control buttons.
+    # These translations are used by the discussion control buttons.
     discussion_controls:
       cannot_reply_button: Can't Reply
       cannot_reply_text: You don't have permission to reply to this discussion.
@@ -173,7 +173,7 @@ core:
       reply_button: => core.ref.reply
       restore_button: => core.ref.restore
 
-    # These strings are used in the discussion list.
+    # These translations are used in the discussion list.
     discussion_list:
       empty_text: "Looks like there are no discussions here. Why don't you create a new one?"
       load_more_button: => core.ref.load_more
@@ -181,14 +181,14 @@ core:
       replied_text: "{username} replied {ago}"
       started_text: "{username} started {ago}"
 
-    # These strings are used in the Edit User modal dialog (admin function).
+    # These translations are used in the Edit User modal dialog (admin function).
     edit_user:
       email_label: => core.ref.email
       password_label: => core.ref.password
       submit_button: => core.ref.save_changes
       username_label: => core.ref.username
 
-    # These strings are used in the Forgot Password modal dialog.
+    # These translations are used in the Forgot Password modal dialog.
     forgot_password:
       dismiss_button: => core.ref.okay
       email_placeholder: => core.ref.email
@@ -197,7 +197,7 @@ core:
       text: Enter your email address and we will send you a link to reset your password.
       title: Forgot Password
 
-    # These strings are used in the header and session dropdown menu.
+    # These translations are used in the header and session dropdown menu.
     header:
       admin_button: Administration
       log_in_link: => core.ref.log_in
@@ -207,7 +207,7 @@ core:
       settings_button: => core.ref.settings
       sign_up_link: => core.ref.sign_up
 
-    # These strings are used on the index page, peripheral to the discussion list.
+    # These translations are used on the index page, peripheral to the discussion list.
     index:
       all_discussions_link: => core.ref.all_discussions
       cannot_start_discussion_button: Can't Start Discussion
@@ -215,7 +215,7 @@ core:
       refresh_tooltip: Refresh
       start_discussion_button: Start a Discussion
 
-    # These strings are used by the sorting control above the discussion list.
+    # These translations are used by the sorting control above the discussion list.
     index_sort:
       latest_button: Latest
       newest_button: Newest
@@ -223,7 +223,7 @@ core:
       relevance_button: Relevance
       top_button: Top
 
-    # These strings are used in the Log In modal dialog.
+    # These translations are used in the Log In modal dialog.
     log_in:
       confirmation_required_message: "You need to confirm your email before you can log in. We've sent a confirmation email to {email}. If it doesn't arrive soon, check your spam folder."
       forgot_password_link: "Forgot password?"
@@ -234,7 +234,7 @@ core:
       title: => core.ref.log_in
       username_or_email_placeholder: Username or Email
 
-    # These strings are used by the Notifications dropdown, a.k.a. "the bell".
+    # These translations are used by the Notifications dropdown, a.k.a. "the bell".
     notifications:
       discussion_renamed_text: "{username} changed the title"
       empty_text: No Notifications
@@ -242,38 +242,38 @@ core:
       title: => core.ref.notifications
       tooltip: => core.ref.notifications
 
-    # These strings are used by tooltips displayed for individual posts.
+    # These translations are used by tooltips displayed for individual posts.
     post:
       edited_tooltip: "{username} edited {ago}"
       number_tooltip: "Post #{number}"
 
-    # These strings are used by the post control buttons.
+    # These translations are used by the post control buttons.
     post_controls:
       delete_button: => core.ref.delete
       delete_forever_button: => core.ref.delete_forever
       edit_button: => core.ref.edit
       restore_button: => core.ref.restore
 
-    # These strings are used in the scrubber to the right of the post stream.
+    # These translations are used in the scrubber to the right of the post stream.
     post_scrubber:
       now_link: Now
       original_post_link: Original Post
       unread_text: "{count} unread"
       viewing_text: "{index} of {count} post|{index} of {count} posts"
 
-    # These strings are displayed between posts in the post stream.
+    # These translations are displayed between posts in the post stream.
     post_stream:
       discussion_renamed_text: "{username} changed the title from {old} to {new}."
       reply_placeholder: => core.ref.write_a_reply
       time_lapsed_text: "{period} later"
 
-    # These strings are used by the search results dropdown list.
+    # These translations are used by the search results dropdown list.
     search:
       all_discussions_button: 'Search all discussions for "{query}"'
       discussions_heading: => core.ref.discussions
       users_heading: Users
 
-    # These strings are used in the Settings page.
+    # These translations are used in the Settings page.
     settings:
       account_heading: Account
       change_email_button: => core.ref.change_email
@@ -286,7 +286,7 @@ core:
       privacy_heading: Privacy
       title: => core.ref.settings
 
-    # These strings are used in the Sign Up modal dialog.
+    # These translations are used in the Sign Up modal dialog.
     sign_up:
       confirmation_message: => core.ref.confirmation_email_sent
       email_placeholder: => core.ref.email
@@ -298,7 +298,7 @@ core:
       username_placeholder: => core.ref.username
       welcome_text: "Welcome, {username}!"
 
-    # These strings are used in the user profile page and profile popup.
+    # These translations are used in the user profile page and profile popup.
     user:
       avatar_remove_button: Remove
       avatar_upload_button: Upload
@@ -310,42 +310,42 @@ core:
       posts_link: Posts
       settings_link: => core.ref.settings
 
-    # These strings are found on the user profile page (admin function).
+    # These translations are found on the user profile page (admin function).
     user_controls:
       button: Controls
       delete_button: => core.ref.delete
       delete_confirmation: "Are you sure you want to delete this user? All of the user's posts will be deleted."
       edit_button: => core.ref.edit
 
-  # Strings in this namespace are used by the forum and admin interfaces.
+  # Translations in this namespace are used by the forum and admin interfaces.
   lib:
 
-    # These strings are displayed as tooltips for discussion badges.
+    # These translations are displayed as tooltips for discussion badges.
     badge:
       hidden_tooltip: Hidden
 
     # This string is displayed in place of the username of deleted user account.
     deleted_user_text: "[deleted]"
 
-    # These strings are displayed as error messages.
+    # These translations are displayed as error messages.
     error:
       generic_message: "Oops! Something went wrong. Please reload the page and try again."
       permission_denied_message: You do not have permission to do that.
       not_found_message: The requested resource was not found.
       rate_limit_exceeded_message: You're going a little too quickly. Please try again in a few seconds.
 
-    # These strings are used as suffixes when abbreviating numbers.
+    # These translations are used as suffixes when abbreviating numbers.
     number_suffix:
       kilo_text: K
       mega_text: M
 
-    # These strings are used to punctuate a series of items.
+    # These translations are used to punctuate a series of items.
     series:
       glue_text: ", "
       two_text: "{first} and {second}"
       three_text: "{first}, {second}, and {third}"
 
-  # Strings in this namespace are used in basic HTML interface.
+  # Translations in this namespace are used in basic HTML interface.
   basic:
     loading_text: Loading...
     load_error_message: Something went wrong while trying to load the full version of this site.
@@ -353,10 +353,10 @@ core:
     next_page_button: Next Page
     previous_page_button: Previous Page
 
-  # Strings in this namespace are used in emails sent by the forum.
+  # Translations in this namespace are used in emails sent by the forum.
   email:
 
-    # These strings are used in emails sent when users register new accounts.
+    # These translations are used in emails sent when users register new accounts.
     activate_account:
       subject: Activate Your New Account
       body: |
@@ -369,7 +369,7 @@ core:
 
         If you did not sign up, please ignore this email.
 
-    # These strings are used in emails sent when users change their email address.
+    # These translations are used in emails sent when users change their email address.
     confirm_email:
       subject: Confirm Your New Email Address
       body: |
@@ -382,7 +382,7 @@ core:
 
         If this was not you, please ignore this email.
 
-    # These strings are used in emails sent when users ask to reset their passwords.
+    # These translations are used in emails sent when users ask to reset their passwords.
     reset_password:
       subject: Reset Your Password
       body: |
@@ -396,10 +396,10 @@ core:
         If you do not wish to change your password, just ignore this email and nothing will happen.
 
   ##
-  # REUSED STRINGS - These keys should not be used directly in code!
+  # REUSED TRANSLATIONS - These keys should not be used directly in code!
   ##
 
-  # Strings in this namespace are referenced by two or more unique keys.
+  # Translations in this namespace are referenced by two or more unique keys.
   ref:
     all_discussions: All Discussions
     change_email: Change Email
@@ -431,7 +431,7 @@ core:
   # GROUP NAMES - These keys are translated at the back end.
   ##
 
-  # Strings in this namespace are used to translate default group names.
+  # Translations in this namespace are used to translate default group names.
   group:
     admin: Admin
     admins: Admins

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -353,42 +353,6 @@ core:
     next_page_button: Next Page
     previous_page_button: Previous Page
 
-  ##
-  # REUSED STRINGS - These keys should not be used directly in code!
-  ##
-
-  # Strings in this namespace are referenced by two or more unique keys.
-  ref:
-    all_discussions: All Discussions
-    change_email: Change Email
-    change_password: Change Password
-    confirmation_email_sent: "We've sent a confirmation email to {email}. If it doesn't arrive soon, check your spam folder."
-    delete: Delete
-    delete_forever: Delete Forever
-    discussions: Discussions
-    edit: Edit
-    email: Email
-    load_more: Load More
-    log_in: Log In
-    log_out: Log Out
-    mark_all_as_read: Mark All as Read
-    notifications: Notifications
-    okay: OK                                     # Referenced by flarum-tags.yml
-    password: Password
-    reply: Reply                                 # Referenced by flarum-mentions.yml
-    restore: Restore
-    save_changes: Save Changes                   # Referenced by flarum-tags.yml
-    settings: Settings
-    sign_up: Sign Up
-    some_others: "{count} other|{count} others"  # Referenced by flarum-likes.yml, flarum-mentions.yml
-    username: Username
-    write_a_reply: Write a Reply...
-    you: You                                     # Referenced by flarum-likes.yml, flarum-mentions.yml
-
-  ##
-  # EMAIL CONTENT
-  ##
-
   # Strings in this namespace are used in emails sent by the forum.
   email:
 
@@ -432,7 +396,39 @@ core:
         If you do not wish to change your password, just ignore this email and nothing will happen.
 
   ##
-  # GROUP NAMES
+  # REUSED STRINGS - These keys should not be used directly in code!
+  ##
+
+  # Strings in this namespace are referenced by two or more unique keys.
+  ref:
+    all_discussions: All Discussions
+    change_email: Change Email
+    change_password: Change Password
+    confirmation_email_sent: "We've sent a confirmation email to {email}. If it doesn't arrive soon, check your spam folder."
+    delete: Delete
+    delete_forever: Delete Forever
+    discussions: Discussions
+    edit: Edit
+    email: Email
+    load_more: Load More
+    log_in: Log In
+    log_out: Log Out
+    mark_all_as_read: Mark All as Read
+    notifications: Notifications
+    okay: OK                                     # Referenced by flarum-tags.yml
+    password: Password
+    reply: Reply                                 # Referenced by flarum-mentions.yml
+    restore: Restore
+    save_changes: Save Changes                   # Referenced by flarum-tags.yml
+    settings: Settings
+    sign_up: Sign Up
+    some_others: "{count} other|{count} others"  # Referenced by flarum-likes.yml, flarum-mentions.yml
+    username: Username
+    write_a_reply: Write a Reply...
+    you: You                                     # Referenced by flarum-likes.yml, flarum-mentions.yml
+
+  ##
+  # GROUP NAMES - These keys are translated at the back end.
   ##
 
   # Strings in this namespace are used to translate default group names.

--- a/locale/flarum-flags.yml
+++ b/locale/flarum-flags.yml
@@ -4,23 +4,23 @@ flarum-flags:
   # UNIQUE KEYS - The following keys are used in only one location each.
   ##
 
-  # Strings in this namespace are used by the admin interface.
+  # Translations in this namespace are used by the admin interface.
   admin:
 
-    # These strings are used in the Permissions page of the admin interface.
+    # These translations are used in the Permissions page of the admin interface.
     permissions:
       flag_posts_label: Flag posts
       view_flags_label: View flagged posts
 
-    # These strings are used in the Flags Settings modal dialog.
+    # These translations are used in the Flags Settings modal dialog.
     settings:
       guidelines_url_label: Community Guidelines URL
       title: Flags Settings
 
-  # Strings in this namespace are used by the forum user interface.
+  # Translations in this namespace are used by the forum user interface.
   forum:
 
-    # These strings are used by the Flag Post modal dialog.
+    # These translations are used by the Flag Post modal dialog.
     flag_post:
       confirmation_message: Thank you for flagging this post. Our moderators will look into it.
       dismiss_button: => core.ref.okay
@@ -34,27 +34,27 @@ flarum-flags:
       submit_button: => flarum-flags.ref.flag_post
       title: => flarum-flags.ref.flag_post
 
-    # These strings are used by the Flagged Posts dropdown, a.k.a. "the flag".
+    # These translations are used by the Flagged Posts dropdown, a.k.a. "the flag".
     flagged_posts:
       empty_text: No Flags
       title: => flarum-flags.ref.flagged_posts
       tooltip: => flarum-flags.ref.flagged_posts
 
-    # These strings are used by the frame displayed around flagged posts.
+    # These translations are used by the frame displayed around flagged posts.
     post:
       dismiss_flag_tooltip: Dismiss Flag
       flagged_by_text: "{username} flagged"
       flagged_by_with_reason_text: "{username} flagged as {reason}"
 
-    # These strings are used by the post control buttons.
+    # These translations are used by the post control buttons.
     post_controls:
       flag_button: Flag
 
   ##
-  # REUSED STRINGS - These keys should not be used directly in code!
+  # REUSED TRANSLATIONS - These keys should not be used directly in code!
   ##
 
-  # Strings in this namespace are referenced by two or more unique keys.
+  # Translations in this namespace are referenced by two or more unique keys.
   ref:
     flag_post: Flag Post
     flagged_posts: Flagged Posts

--- a/locale/flarum-likes.yml
+++ b/locale/flarum-likes.yml
@@ -4,22 +4,22 @@ flarum-likes:
   # UNIQUE KEYS - The following keys are used in only one location each.
   ##
 
-  # Strings in this namespace are used by the admin interface.
+  # Translations in this namespace are used by the admin interface.
   admin:
 
-    # These strings are used in the Permissions page of the admin interface.
+    # These translations are used in the Permissions page of the admin interface.
     permissions:
       like_posts_label: Like posts
 
-  # Strings in this namespace are used by the forum user interface.
+  # Translations in this namespace are used by the forum user interface.
   forum:
 
-    # These strings are used by the Notifications dropdown, a.k.a. "the bell".
+    # These translations are used by the Notifications dropdown, a.k.a. "the bell".
     notifications:
       post_liked_text: "{username} liked your post"  # Can be pluralized to agree with the number of users!
       others_text: => core.ref.some_others
 
-    # These strings are displayed beneath individual posts.
+    # These translations are displayed beneath individual posts.
     post:
       like_link: Like
       liked_by_text: "{users} likes this.|{users} like this."
@@ -28,10 +28,10 @@ flarum-likes:
       unlike_link: Unlike
       you_text: => core.ref.you
 
-    # These strings are used by the Users Who Like This modal dialog.
+    # These translations are used by the Users Who Like This modal dialog.
     post_likes:
       title: Users Who Like This
 
-    # These strings are used in the Settings page.
+    # These translations are used in the Settings page.
     settings:
       notify_post_liked_label: Someone likes one of my posts

--- a/locale/flarum-lock.yml
+++ b/locale/flarum-lock.yml
@@ -4,34 +4,34 @@ flarum-lock:
   # UNIQUE KEYS - The following keys are used in only one location each.
   ##
 
-  # Strings in this namespace are used by the admin interface.
+  # Translations in this namespace are used by the admin interface.
   admin:
 
-    # These strings are used in the Permissions page of the admin interface.
+    # These translations are used in the Permissions page of the admin interface.
     permissions:
       lock_discussions_label: Lock discussions
 
-  # Strings in this namespace are used by the forum user interface.
+  # Translations in this namespace are used by the forum user interface.
   forum:
 
-    # These strings are displayed as tooltips for discussion badges.
+    # These translations are displayed as tooltips for discussion badges.
     badge:
       locked_tooltip: Locked
 
-    # These strings are used by the discussion control buttons.
+    # These translations are used by the discussion control buttons.
     discussion_controls:
       lock_button: Lock
       unlock_button: Unlock
 
-    # These strings are used by the Notifications dropdown, a.k.a. "the bell".
+    # These translations are used by the Notifications dropdown, a.k.a. "the bell".
     notifications:
       discussion_locked_text: "{username} locked"
 
-    # These strings are displayed between posts in the post stream.
+    # These translations are displayed between posts in the post stream.
     post_stream:
       discussion_locked_text: "{username} locked the discussion."
       discussion_unlocked_text: "{username} unlocked the discussion."
 
-    # These strings are used in the Settings page.
+    # These translations are used in the Settings page.
     settings:
       notify_discussion_locked_label: Someone locks a discussion I started

--- a/locale/flarum-mentions.yml
+++ b/locale/flarum-mentions.yml
@@ -4,20 +4,20 @@ flarum-mentions:
   # UNIQUE KEYS - The following keys are used in only one location each.
   ##
 
-  # Strings in this namespace are used by the forum user interface.
+  # Translations in this namespace are used by the forum user interface.
   forum:
 
-    # These strings are used by the composer (reply autocompletion function).
+    # These translations are used by the composer (reply autocompletion function).
     composer:
       reply_to_post_text: "Reply to #{number}"
 
-    # These strings are used by the Notifications dropdown, a.k.a. "the bell".
+    # These translations are used by the Notifications dropdown, a.k.a. "the bell".
     notifications:
       post_mentioned_text: "{username} replied to your post"  # Can be pluralized to agree with the number of users!
       others_text: => core.ref.some_others
       user_mentioned_text: "{username} mentioned you"
 
-    # These strings are displayed beneath individual posts.
+    # These translations are displayed beneath individual posts.
     post:
       mentioned_by_text: "{users} replied to this."       # Can be pluralized to agree with the number of users!
       mentioned_by_self_text: "{users} replied to this."  # Can be pluralized to agree with the number of users!
@@ -25,7 +25,7 @@ flarum-mentions:
       reply_link: => core.ref.reply
       you_text: => core.ref.you
 
-    # These strings are used in the Settings page.
+    # These translations are used in the Settings page.
     settings:
       notify_post_mentioned_label: Someone replies to one of my posts
       notify_user_mentioned_label: Someone mentions me in a post

--- a/locale/flarum-pusher.yml
+++ b/locale/flarum-pusher.yml
@@ -4,19 +4,19 @@ flarum-pusher:
   # UNIQUE KEYS - The following keys are used in only one location each.
   ##
 
-  # Strings in this namespace are used by the admin interface.
+  # Translations in this namespace are used by the admin interface.
   admin:
 
-    # These strings are used in the Pusher Settings modal dialog.
+    # These translations are used in the Pusher Settings modal dialog.
     pusher_settings:
       app_id_label: App ID
       app_key_label: App Key
       app_secret_label: App Secret
       title: Pusher Settings
 
-  # Strings in this namespace are used by the admin interface.
+  # Translations in this namespace are used by the admin interface.
   forum:
 
-    # These strings are used in the discussion list.
+    # These translations are used in the discussion list.
     discussion_list:
       show_updates_text: "Show {count} updated discussion|Show {count} updated discussions"

--- a/locale/flarum-sticky.yml
+++ b/locale/flarum-sticky.yml
@@ -4,34 +4,34 @@ flarum-sticky:
   # UNIQUE KEYS - The following keys are used in only one location each.
   ##
 
-  # Strings in this namespace are used by the admin interface.
+  # Translations in this namespace are used by the admin interface.
   admin:
 
-    # These strings are used in the Permissions page of the admin interface.
+    # These translations are used in the Permissions page of the admin interface.
     permissions:
       sticky_discussions_label: Sticky discussions
 
-  # Strings in this namespace are used by the forum user interface.
+  # Translations in this namespace are used by the forum user interface.
   forum:
 
-    # These strings are displayed as tooltips for discussion badges.
+    # These translations are displayed as tooltips for discussion badges.
     badge:
       sticky_tooltip: => flarum-sticky.ref.sticky
 
-    # These strings are used by the discussion control buttons.
+    # These translations are used by the discussion control buttons.
     discussion_controls:
       sticky_button: => flarum-sticky.ref.sticky
       unsticky_button: Unsticky
 
-    # These strings are displayed between posts in the post stream.
+    # These translations are displayed between posts in the post stream.
     post_stream:
       discussion_stickied_text: "{username} stickied the discussion."
       discussion_unstickied_text: "{username} unstickied the discussion."
 
   ##
-  # REUSED STRINGS - These keys should not be used directly in code!
+  # REUSED TRANSLATIONS - These keys should not be used directly in code!
   ##
 
-  # Strings in this namespace are referenced by two or more unique keys.
+  # Translations in this namespace are referenced by two or more unique keys.
   ref:
     sticky: Sticky

--- a/locale/flarum-subscriptions.yml
+++ b/locale/flarum-subscriptions.yml
@@ -4,33 +4,33 @@ flarum-subscriptions:
   # UNIQUE KEYS - The following keys are used in only one location each.
   ##
 
-  # Strings in this namespace are used by the forum user interface.
+  # Translations in this namespace are used by the forum user interface.
   forum:
 
-    # These strings are displayed as tooltips for discussion badges.
+    # These translations are displayed as tooltips for discussion badges.
     badge:
       following_tooltip: => flarum-subscriptions.ref.following
       ignoring_tooltip: => flarum-subscriptions.ref.ignoring
 
-    # These strings are used by the discussion control buttons.
+    # These translations are used by the discussion control buttons.
     discussion_controls:
       follow_button: => flarum-subscriptions.ref.follow
       unfollow_button: Unfollow
       unignore_button: Unignore
 
-    # These strings are used on the index page, peripheral to the discussion list.
+    # These translations are used on the index page, peripheral to the discussion list.
     index:
       following_link: => flarum-subscriptions.ref.following
 
-    # These strings are used by the Notifications dropdown, a.k.a. "the bell".
+    # These translations are used by the Notifications dropdown, a.k.a. "the bell".
     notifications:
       new_post_text: "{username} posted"
 
-    # These strings are used in the Settings page.
+    # These translations are used in the Settings page.
     settings:
       notify_new_post_label: Someone posts in a discussion I'm following
 
-    # These strings are used in the subscription menu displayed to the right of the post stream.
+    # These translations are used in the subscription menu displayed to the right of the post stream.
     sub_controls:
       follow_button: => flarum-subscriptions.ref.follow
       following_button: => flarum-subscriptions.ref.following
@@ -43,10 +43,10 @@ flarum-subscriptions:
       notify_alert_tooltip: Get a forum notification when there are new posts
 
   ##
-  # REUSED STRINGS - These keys should not be used directly in code!
+  # REUSED TRANSLATIONS - These keys should not be used directly in code!
   ##
 
-  # Strings in this namespace are referenced by two or more unique keys.
+  # Translations in this namespace are referenced by two or more unique keys.
   ref:
     follow: Follow
     following: Following

--- a/locale/flarum-tags.yml
+++ b/locale/flarum-tags.yml
@@ -4,14 +4,14 @@ flarum-tags:
   # UNIQUE KEYS - The following keys are used in only one location each.
   ##
 
-  # Strings in this namespace are used by the admin interface.
+  # Translations in this namespace are used by the admin interface.
   admin:
 
-    # These strings are used in the Basics page.
+    # These translations are used in the Basics page.
     basics:
       tags_label: => flarum-tags.ref.tags
 
-    # These strings are used in the Edit Tag modal dialog.
+    # These translations are used in the Edit Tag modal dialog.
     edit_tag:
       color_label: Color
       description_label: Description
@@ -24,17 +24,17 @@ flarum-tags:
       submit_button: => core.ref.save_changes
       title: => flarum-tags.ref.create_tag
 
-    # These strings are used in the navigation bar.
+    # These translations are used in the navigation bar.
     nav:
       tags_button: => flarum-tags.ref.tags
       tags_text: Manage the list of tags available to organise discussions with.
 
-    # These strings are used in the Permissions page of the admin interface.
+    # These translations are used in the Permissions page of the admin interface.
     permissions:
       restrict_by_tag_heading: Restrict by Tag
       tag_discussions_label: Tag discussions
 
-    # These strings are used in the Tag Settings modal dialog.
+    # These translations are used in the Tag Settings modal dialog.
     tag_settings:
       range_separator_text: " to "
       required_primary_heading: Required Number of Primary Tags
@@ -43,7 +43,7 @@ flarum-tags:
       required_secondary_text: Enter the minimum and maximum number of secondary tags that may be applied to a discussion.
       title: Tag Settings
 
-    # These strings are used in the Tags page.
+    # These translations are used in the Tags page.
     tags:
       about_tags_text: "Tags are used to categorize discussions. Primary tags are like traditional forum categories: they can be arranged in a two-level hierarchy. Secondary tags do not have hierarchy or order, and are useful for micro-categorization."
       create_tag_button: => flarum-tags.ref.create_tag
@@ -51,10 +51,10 @@ flarum-tags:
       secondary_heading: Secondary Tags
       settings_button: Settings
 
-  # Strings in this namespace are used by the forum user interface.
+  # Translations in this namespace are used by the forum user interface.
   forum:
 
-    # These strings are used by the Choose Tags modal dialog.
+    # These translations are used by the Choose Tags modal dialog.
     choose_tags:
       choose_primary_placeholder: "Choose a primary tag|Choose {count} primary tags"
       choose_secondary_placeholder: "Choose 1 more tag|Choose {count} more tags"
@@ -62,38 +62,38 @@ flarum-tags:
       submit_button: => core.ref.okay
       title: Choose Tags for Your Discussion
 
-    # These strings are used by the composer when starting a discussion.
+    # These translations are used by the composer when starting a discussion.
     composer_discussion:
       choose_tags_link: Choose Tags
 
-    # These strings are used by the discussion control buttons.
+    # These translations are used by the discussion control buttons.
     discussion_controls:
       edit_tags_button: Edit Tags
 
-    # These strings are used on the index page, peripheral to the discussion list.
+    # These translations are used on the index page, peripheral to the discussion list.
     index:
       tags_link: => flarum-tags.ref.tags
       more_link: More...
       untagged_link: Untagged
 
-    # These strings are displayed between posts in the post stream.
+    # These translations are displayed between posts in the post stream.
     post_stream:
       added_tags_text: "{username} added the {tagsAdded}."
       added_and_removed_tags_text: "{username} added the {tagsAdded} and removed the {tagsRemoved}."
       removed_tags_text: "{username} removed the {tagsRemoved}."
       tags_text: "{tags} tag|{tags} tags"
 
-  # Strings in this namespace are used by the forum and admin interfaces.
+  # Translations in this namespace are used by the forum and admin interfaces.
   lib:
 
     # This string is displayed in place of the name of a tag that's been deleted.
     deleted_tag_text: Deleted
 
   ##
-  # REUSED STRINGS - These keys should not be used directly in code!
+  # REUSED TRANSLATIONS - These keys should not be used directly in code!
   ##
 
-  # Strings in this namespace are referenced by two or more unique keys.
+  # Translations in this namespace are referenced by two or more unique keys.
   ref:
     create_tag: Create Tag
     name: Name


### PR DESCRIPTION
- Moves `ref` below `email`, adjacent to `group`.
- Deletes block comment for email.
- Adds detailed information to block comment for `group`.