### PR TITLE
Added language key for allowing edit of tags. 

### DIFF
--- a/locale/flarum-tags.yml
+++ b/locale/flarum-tags.yml
@@ -33,6 +33,7 @@ flarum-tags:
     permissions:
       restrict_by_tag_heading: Restrict by Tag
       tag_discussions_label: Tag discussions
+      allow_edit_tags_label: Allow edit tags
 
     # These strings are used in the Tag Settings modal dialog.
     tag_settings:

--- a/locale/flarum-tags.yml
+++ b/locale/flarum-tags.yml
@@ -33,7 +33,7 @@ flarum-tags:
     permissions:
       restrict_by_tag_heading: Restrict by Tag
       tag_discussions_label: Tag discussions
-      allow_edit_tags_label: Allow edit tags
+      allow_edit_tags_label: Allow tag editing
 
     # These strings are used in the Tag Settings modal dialog.
     tag_settings:


### PR DESCRIPTION
Part of fix for flarum/core#330

This PR adds a language key for the PermissionGrid in the admin area.
There is a new setting to set how long a author can edit the tags for his discussion. This adds a translation key for it.