### PR TITLE
Do not ask to create a new discussion anymore

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -175,7 +175,7 @@ core:
 
     # These strings are used in the discussion list.
     discussion_list:
-      empty_text: "Looks like there are no discussions here. Why don't you create a new one?"
+      empty_text: "It looks like there are no discussions here."
       load_more_button: => core.ref.load_more
       mark_as_read_tooltip: Mark as Read
       replied_text: "{username} replied {ago}"


### PR DESCRIPTION
This string is also used in the **Following** page when there are no discussions followed by the user. In that case, it doesn't helps the user to create a new discussion (he just can't create a followed discussion anyway). To prevent a new string to be added just for that, I think it's better to remove the question and display a generic message.