### PR TITLE
Adds required double quotes to a translation.

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -48,7 +48,7 @@ core:
     edit_css:
       customize_text: "Customize your forum's appearance by adding your own LESS/CSS code to be applied on top of Flarum's <a>default styles</a>."
       submit_button: => core.ref.save_changes
-      title:
+      title: Edit Custom CSS
 
     # These translations are used in the Edit Group modal dialog.
     edit_group:

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -46,7 +46,7 @@ core:
 
     # These translations are used in the Edit Custom CSS modal dialog.
     edit_css:
-      customize_text: Customize your forum's appearance by adding your own LESS/CSS code to be applied on top of Flarum's <a>default styles</a>.
+      customize_text: "Customize your forum's appearance by adding your own LESS/CSS code to be applied on top of Flarum's <a>default styles</a>."
       submit_button: => core.ref.save_changes
       title:
 


### PR DESCRIPTION
Forgot the double quotes around a translation with HTML tags. Sorry!